### PR TITLE
Fix tests to use bundled pbmc dataset

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -47,7 +47,10 @@ def get_equivalent_matrix(file):
 @pytest.fixture(scope="module")
 def adata_for_loupe():
     """Provides the AnnData object for Loupe conversion."""
-    adata_raw = sc.datasets.pbmc3k_processed().raw.to_adata()
+    adata_path = os.path.join(
+        os.path.dirname(__file__), "data", "pbmc3k_processed.h5ad"
+    )
+    adata_raw = sc.read_h5ad(adata_path).raw.to_adata()
     return reverse_engineer_counts(adata_raw)
 
 @pytest.fixture(scope="module")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 import pytest
 import scanpy as sc  # type: ignore
@@ -24,7 +25,10 @@ def reverse_engineer_counts(adata, n_counts_column="n_counts"):
 
 @pytest.fixture
 def mock_data():
-    return reverse_engineer_counts(sc.datasets.pbmc3k_processed())
+    adata_path = os.path.join(
+        os.path.dirname(__file__), "data", "pbmc3k_processed.h5ad"
+    )
+    return reverse_engineer_counts(sc.read_h5ad(adata_path))
 
 @pytest.fixture
 def generate_long_df():


### PR DESCRIPTION
## Summary
- fix `pbmc3k_processed` fixtures to use local h5ad file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'h5py')*

------
https://chatgpt.com/codex/tasks/task_e_68436b9b5ec88329895a9500d3689acd